### PR TITLE
fix(typeorm-aws-connector): stage credential rotation reconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ## 💡 Highlights
 
 - 🔐 Zero-credential codebase — resolves all database config from AWS SSM Parameter Store & Secrets Manager at runtime
-- ♻️ Built-in automatic credential rotation with health checks, emergency recovery, and zero-downtime connection swaps
+- ♻️ Built-in automatic credential rotation with health checks, staged driver promotion, and graceful old-pool drainage
 - 🏗️ Split-source architecture — infra teams own host/port/secrets, app teams own pool/timeout/sync settings independently
 - 📦 Dual ESM/CJS module output with full TypeScript declarations and broad NestJS compatibility (v8–v11)
 
@@ -37,7 +37,7 @@
 ## 📖 Description
 **NestJS-TypeORM-AWS-Connector** is a production-grade NestJS module that eliminates the pain of managing database configuration in AWS-hosted applications. Instead of hardcoding credentials or juggling environment variables, this connector resolves your entire TypeORM `DataSourceOptions` from **AWS Systems Manager Parameter Store** and **AWS Secrets Manager** — with built-in credential rotation.
 
-In modern cloud-native architectures, database credentials are rotated regularly for security compliance. Traditional approaches break connections during rotation, causing downtime. This connector solves that with an intelligent **automatic credential rotation service** that seamlessly refreshes database connections with zero downtime, including emergency recovery after consecutive failures.
+In modern cloud-native architectures, database credentials are rotated regularly for security compliance. Traditional approaches break connections during rotation, causing downtime. This connector avoids destructive mid-run `DataSource` teardown by validating a replacement connection first, promoting the new driver for future query runners, and retiring the previous pool only after existing query runners drain.
 
 ### Real-World Use Cases
 
@@ -65,8 +65,8 @@ The connector uses a **split-source model**: infrastructure-owned parameters (ho
 ## 🚀 Features
 - ✨ ****AWS Parameter Store Integration** — Resolves database host, port, name, type, and tuning parameters from structured SSM paths with hierarchical namespace support**
 - ✨ ****AWS Secrets Manager Integration** — Fetches username/password credentials from Secrets Manager with proper error handling for missing or malformed secrets**
-- ✨ ****Automatic Credential Rotation** — Configurable interval-based rotation that swaps database connections with zero downtime, including subscriber preservation**
-- ✨ ****Emergency Recovery** — After 3 consecutive rotation failures, automatically attempts full connection recovery with fresh credentials from AWS**
+- ✨ ****Automatic Credential Rotation** — Configurable interval-based rotation that validates a replacement connection before promoting it for future query runners**
+- ✨ ****Emergency Recovery** — After 3 consecutive rotation failures, automatically retries recovery without destructively tearing down the live `DataSource`**
 - ✨ ****Connection Health Validation** — Validates both existing and new connections with `SELECT 1` queries before and after rotation**
 - ✨ ****Split-Source Configuration Model** — Infrastructure-owned settings (host, port, secret-id) use canonical AWS namespaces; app-owned settings use your module namespace**
 - ✨ ****Raw Value Overrides** — Bypass SSM entirely for any field by providing direct values — perfect for local development with `host: '127.0.0.1'`**
@@ -124,10 +124,10 @@ sequenceDiagram
         Rotator->>Connector: getTypeOrmOptions()
         Connector->>SM: Fetch fresh credentials
         SM-->>Connector: New username + password
-        Rotator->>TypeORM: Destroy old connection
-        Rotator->>TypeORM: Initialize new DataSource
+        Rotator->>TypeORM: Initialize replacement DataSource
         Rotator->>TypeORM: Verify with SELECT 1
-        Rotator->>TypeORM: Swap driver + restore subscribers
+        Rotator->>TypeORM: Promote replacement driver for future query runners
+        Rotator->>TypeORM: Retire previous pool after active query runners drain
     end
 ```
 
@@ -337,10 +337,13 @@ TypeOrmAwsConnectorModule.register({
 The rotation service will:
 1. Validate current connection health
 2. Fetch fresh credentials from AWS Secrets Manager
-3. Create a new DataSource with updated credentials
-4. Verify the new connection with a `SELECT 1` query
-5. Swap the driver seamlessly, preserving all subscribers
-6. Attempt emergency recovery after 3 consecutive failures
+3. Create and initialize a replacement `DataSource` with the updated credentials
+4. Verify the replacement connection with a `SELECT 1` query
+5. Promote the replacement driver for future query runners without destroying the live `DataSource`
+6. Dispose the previous pool only after query runners created before the promotion are released
+7. Attempt emergency recovery after 3 consecutive failures
+
+Rotation is intended for long-lived services. For one-shot jobs, migrations, or explicit CLI tasks, keep `rotation.isEnabled` disabled so the connector does not register a background interval.
 
 ---
 
@@ -402,7 +405,7 @@ Required fields (`host`, `port`, `databaseName`, `type`, `secretId`) throw expli
 |---|---|
 | Dual ESM/CJS module output | ✅ Done |
 | AWS Secrets Manager credential resolution | ✅ Done |
-| Automatic credential rotation with zero downtime | ✅ Done |
+| Automatic credential rotation with staged driver promotion | ✅ Done |
 | Emergency recovery after consecutive rotation failures | ✅ Done |
 | Split-source configuration model (infra vs app namespaces) | ✅ Done |
 | Raw value overrides for local development | ✅ Done |
@@ -429,7 +432,7 @@ A: No! Use raw value overrides to bypass AWS entirely during local development. 
 A: Currently PostgreSQL (`EDatabaseType.POSTGRES`) and MySQL (`EDatabaseType.MYSQL`). The `type` field is resolved from SSM or set directly.
 
 **Q: What happens if AWS Secrets Manager is unreachable during rotation?**
-A: The rotation service catches the error, increments a failure counter, and logs it. After 3 consecutive failures, it attempts an emergency recovery with a completely fresh DataSource. The existing connection continues to function until rotation succeeds.
+A: The rotation service catches the error, increments a failure counter, and logs it. After 3 consecutive failures, it attempts an emergency recovery with a fresh replacement connection. Failed replacements are discarded, and the currently promoted pool stays in place until a later rotation succeeds.
 
 **Q: Can I use this without `@elsikora/nestjs-aws-parameter-store-config`?**
 A: No. The connector depends on `ParameterStoreConfigService.get()` for SSM lookups. You must register `ParameterStoreConfigModule` first. However, if you provide raw values for all fields, SSM lookups won't actually be invoked.
@@ -441,7 +444,7 @@ A: Infrastructure-owned fields like `host`, `port`, and `secretId` default to ca
 A: Yes. The peer dependency accepts `@nestjs/common ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0`.
 
 **Q: How do I disable credential rotation?**
-A: Don't set the `rotation` config, or explicitly set `rotation.isEnabled: false`. The `RotatorService` will skip interval registration entirely.
+A: Don't set the `rotation` config, or explicitly set `rotation.isEnabled: false`. The `RotatorService` will skip interval registration entirely. This is the recommended mode for one-shot jobs, migrations, and other short-lived processes.
 
 **Q: What's the default rotation interval?**
 A: 1 hour (3,600,000 ms). Override it via `rotation.intervalMs` or the SSM path `typeorm/rotation/interval-ms`.

--- a/src/modules/typeorm-aws-connector/rotator/rotator.service.ts
+++ b/src/modules/typeorm-aws-connector/rotator/rotator.service.ts
@@ -1,18 +1,40 @@
-import { Injectable, Logger, OnModuleInit } from "@nestjs/common";
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from "@nestjs/common";
 import { SchedulerRegistry } from "@nestjs/schedule";
-import { DataSource, DataSourceOptions, EntitySubscriberInterface, QueryRunner } from "typeorm";
+import { DataSource, DataSourceOptions, QueryRunner } from "typeorm";
 
 import { TypeOrmAwsConnectorService } from "../typeorm-aws-connector.service";
 
+type TMutableDriver = {
+	connection: DataSource;
+	options: DataSourceOptions;
+} & DataSource["driver"];
+
+type TQueryRunnerMode = Parameters<DataSource["createQueryRunner"]>[0];
+
+type TRetiredDriver = {
+	driver: TMutableDriver;
+	generation: number;
+};
+
 @Injectable()
-export class RotatorService implements OnModuleInit {
+export class RotatorService implements OnModuleDestroy, OnModuleInit {
+	private readonly activeQueryRunnerCountsByGeneration: Map<number, number> = new Map<number, number>();
+
 	private consecutiveFailures: number = 0;
+
+	private currentDriverGeneration: number = 0;
+
+	private isDataSourceTrackingInstalled: boolean = false;
 
 	private isRotationInProgress: boolean = false;
 
 	private readonly LOGGER: Logger;
 
 	private readonly MAX_CONSECUTIVE_FAILURES: number = 3;
+
+	private retiredDriverDisposal: Promise<void> = Promise.resolve();
+
+	private retiredDrivers: Array<TRetiredDriver> = [];
 
 	constructor(
 		private readonly dataSource: DataSource | undefined,
@@ -23,6 +45,10 @@ export class RotatorService implements OnModuleInit {
 		this.LOGGER = new Logger(`${RotatorService.name}:${this.rotationIntervalName}`);
 	}
 
+	async onModuleDestroy(): Promise<void> {
+		await this.scheduleRetiredDriverDisposal(true);
+	}
+
 	onModuleInit(): void {
 		const rotationConfig: { intervalMs: number; isEnabled: boolean } = this.connectorService.getRotationConfig();
 
@@ -30,7 +56,8 @@ export class RotatorService implements OnModuleInit {
 			return;
 		}
 
-		this.getRequiredDataSource();
+		const dataSource: DataSource = this.getRequiredDataSource();
+		this.installDataSourceTracking(dataSource);
 
 		const interval: ReturnType<typeof setInterval> = setInterval(() => {
 			void this.safeRotateDatabaseConnection();
@@ -44,89 +71,49 @@ export class RotatorService implements OnModuleInit {
 		this.LOGGER.log("Launching DB credentials rotation interval...");
 
 		const dataSource: DataSource = this.getRequiredDataSource();
+		this.installDataSourceTracking(dataSource);
+
+		if (!dataSource.isInitialized) {
+			this.LOGGER.warn("Skipping DB credentials rotation because the live DataSource is not initialized yet");
+
+			return;
+		}
 
 		// First verify the current connection is actually healthy
 		await this.validateConnectionHealth(dataSource);
 
-		// Backup existing configuration
-		const currentOptions: DataSourceOptions = dataSource.options;
-		const subscribers: Array<EntitySubscriberInterface> = [...dataSource.subscribers];
-
 		// Get fresh credentials from AWS
 		const freshOptions: DataSourceOptions = await this.connectorService.getTypeOrmOptions();
+		const mergedOptions: DataSourceOptions = this.mergeDataSourceOptions(dataSource.options, freshOptions);
+		const nextDataSource: DataSource = this.createReplacementDataSource(mergedOptions);
 
-		const mergedOptions: DataSourceOptions = {
-			...currentOptions,
-			// eslint-disable-next-line @elsikora/typescript/no-unsafe-assignment
-			extra: {
-				...currentOptions.extra,
-			},
-			// @ts-ignore
-			// eslint-disable-next-line @elsikora/typescript/no-unsafe-assignment
-			host: freshOptions.host,
-			// @ts-ignore
-			// eslint-disable-next-line @elsikora/typescript/no-unsafe-assignment
-			password: freshOptions.password,
-			// @ts-ignore
-			// eslint-disable-next-line @elsikora/typescript/no-unsafe-assignment
-			username: freshOptions.username,
-		};
+		try {
+			await nextDataSource.initialize();
+			await this.verifyNewConnection(nextDataSource);
+		} catch (error) {
+			await this.destroyReplacementDataSource(nextDataSource);
 
-		// Destroy old connection only if initialized
-		if (dataSource.isInitialized) {
-			await dataSource.destroy();
+			throw error;
 		}
 
-		// Create and initialize a new data source with fresh credentials
-		const newDataSource: DataSource = new DataSource(mergedOptions);
-		await newDataSource.initialize();
-
-		// Verify the new connection works by performing a simple query
-		await this.verifyNewConnection(newDataSource);
-
-		// Re-add subscribers
-		for (const subscriber of subscribers) {
-			newDataSource.subscribers.push(subscriber);
-		}
-
-		// Update the existing data source with new connection
-		dataSource.setOptions(mergedOptions);
-		this.replaceDataSourceDriver(dataSource, newDataSource);
+		this.promoteReplacementDataSource(dataSource, nextDataSource, mergedOptions);
+		void this.scheduleRetiredDriverDisposal(false);
 
 		this.LOGGER.log("Rotation completed successfully!");
+	}
+
+	protected createReplacementDataSource(options: DataSourceOptions): DataSource {
+		return new DataSource(options);
+	}
+
+	private asMutableDriver(driver: DataSource["driver"]): TMutableDriver {
+		return driver as TMutableDriver;
 	}
 
 	private async attemptEmergencyRecovery(): Promise<void> {
 		try {
 			this.LOGGER.log("Attempting emergency database connection recovery...");
-			const dataSource: DataSource = this.getRequiredDataSource();
-
-			// Get fresh credentials and connection options from AWS
-			const freshOptions: DataSourceOptions = await this.connectorService.getTypeOrmOptions();
-
-			// If the data source is still initialized, destroy it first
-			if (dataSource.isInitialized) {
-				await dataSource.destroy();
-			}
-
-			// Create a completely new data source with fresh options
-			const recoveryDataSource: DataSource = new DataSource({
-				...freshOptions,
-			});
-
-			// Initialize the recovery data source
-			await recoveryDataSource.initialize();
-
-			// Transfer subscribers
-			const subscribers: Array<EntitySubscriberInterface> = [...dataSource.subscribers];
-
-			for (const subscriber of subscribers) {
-				recoveryDataSource.subscribers.push(subscriber);
-			}
-
-			// Replace the driver and connection objects
-			dataSource.setOptions(recoveryDataSource.options);
-			this.replaceDataSourceDriver(dataSource, recoveryDataSource);
+			await this.rotateDatabaseConnection();
 
 			// Reset failure counter after successful recovery
 			this.consecutiveFailures = 0;
@@ -134,6 +121,65 @@ export class RotatorService implements OnModuleInit {
 		} catch (recoveryError) {
 			this.LOGGER.error(`Emergency recovery failed: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`);
 		}
+	}
+
+	private decrementActiveQueryRunnerCount(generation: number): void {
+		const nextCount: number = (this.activeQueryRunnerCountsByGeneration.get(generation) ?? 0) - 1;
+
+		if (nextCount <= 0) {
+			this.activeQueryRunnerCountsByGeneration.delete(generation);
+
+			return;
+		}
+
+		this.activeQueryRunnerCountsByGeneration.set(generation, nextCount);
+	}
+
+	private async destroyReplacementDataSource(dataSource: DataSource): Promise<void> {
+		if (!dataSource.isInitialized) {
+			return;
+		}
+
+		await dataSource.destroy();
+	}
+
+	private async disposeRetiredDrivers(force: boolean): Promise<void> {
+		const pendingRetiredDrivers: Array<TRetiredDriver> = [];
+
+		for (const retiredDriver of this.retiredDrivers) {
+			const activeQueryRunnerCount: number = this.activeQueryRunnerCountsByGeneration.get(retiredDriver.generation) ?? 0;
+
+			if (!force && activeQueryRunnerCount > 0) {
+				pendingRetiredDrivers.push(retiredDriver);
+
+				continue;
+			}
+
+			try {
+				await retiredDriver.driver.disconnect();
+				this.LOGGER.debug(`Disposed retired DB driver from generation ${String(retiredDriver.generation)}`);
+			} catch (error) {
+				this.LOGGER.error(`Failed to dispose retired DB driver from generation ${String(retiredDriver.generation)}: ${error instanceof Error ? error.message : String(error)}`);
+
+				if (!force) {
+					pendingRetiredDrivers.push(retiredDriver);
+				}
+			}
+		}
+
+		this.retiredDrivers = pendingRetiredDrivers;
+	}
+
+	private getExtraOptions(options: DataSourceOptions): Record<string, unknown> {
+		const extraCandidate: unknown = (options as { extra?: unknown }).extra;
+
+		if (typeof extraCandidate !== "object" || extraCandidate === null || Array.isArray(extraCandidate)) {
+			return {};
+		}
+
+		return {
+			...(extraCandidate as Record<string, unknown>),
+		};
 	}
 
 	private getRequiredDataSource(): DataSource {
@@ -144,10 +190,65 @@ export class RotatorService implements OnModuleInit {
 		return this.dataSource;
 	}
 
-	private replaceDataSourceDriver(dataSource: DataSource, nextDataSource: DataSource): void {
-		const mutableDataSource: { driver: DataSource["driver"] } & DataSource = dataSource;
+	private incrementActiveQueryRunnerCount(generation: number): void {
+		this.activeQueryRunnerCountsByGeneration.set(generation, (this.activeQueryRunnerCountsByGeneration.get(generation) ?? 0) + 1);
+	}
 
-		mutableDataSource.driver = nextDataSource.driver;
+	private installDataSourceTracking(dataSource: DataSource): void {
+		if (this.isDataSourceTrackingInstalled) {
+			return;
+		}
+
+		const originalCreateQueryRunner: DataSource["createQueryRunner"] = dataSource.createQueryRunner.bind(dataSource);
+
+		dataSource.createQueryRunner = (mode?: TQueryRunnerMode): QueryRunner => {
+			const generation: number = this.currentDriverGeneration;
+			this.incrementActiveQueryRunnerCount(generation);
+
+			try {
+				const queryRunner: QueryRunner = originalCreateQueryRunner(mode);
+
+				this.trackQueryRunnerRelease(generation, queryRunner);
+
+				return queryRunner;
+			} catch (error) {
+				this.decrementActiveQueryRunnerCount(generation);
+
+				throw error;
+			}
+		};
+
+		this.isDataSourceTrackingInstalled = true;
+	}
+
+	private mergeDataSourceOptions(currentOptions: DataSourceOptions, freshOptions: DataSourceOptions): DataSourceOptions {
+		this.validateRotationDataSourceOptions(currentOptions);
+		this.validateRotationDataSourceOptions(freshOptions);
+
+		return {
+			...currentOptions,
+			...freshOptions,
+			extra: {
+				...this.getExtraOptions(currentOptions),
+				...this.getExtraOptions(freshOptions),
+			},
+		} as DataSourceOptions;
+	}
+
+	private promoteReplacementDataSource(dataSource: DataSource, nextDataSource: DataSource, mergedOptions: DataSourceOptions): void {
+		const mutableCurrentDriver: TMutableDriver = this.asMutableDriver(dataSource.driver);
+		const mutableNextDriver: TMutableDriver = this.asMutableDriver(nextDataSource.driver);
+		const retiredGeneration: number = this.currentDriverGeneration;
+
+		this.currentDriverGeneration += 1;
+		mutableNextDriver.connection = dataSource;
+		dataSource.driver = mutableNextDriver;
+		dataSource.setOptions(mergedOptions);
+		mutableNextDriver.options = dataSource.options;
+		this.retiredDrivers.push({
+			driver: mutableCurrentDriver,
+			generation: retiredGeneration,
+		});
 	}
 
 	private async safeRotateDatabaseConnection(): Promise<void> {
@@ -175,6 +276,43 @@ export class RotatorService implements OnModuleInit {
 		}
 	}
 
+	private scheduleRetiredDriverDisposal(force: boolean): Promise<void> {
+		const nextDisposal: Promise<void> = this.retiredDriverDisposal
+			.catch((error: unknown) => {
+				this.LOGGER.error(`Retired driver disposal chain failed: ${error instanceof Error ? error.message : String(error)}`);
+			})
+			.then(async () => {
+				await this.disposeRetiredDrivers(force);
+			});
+
+		this.retiredDriverDisposal = nextDisposal;
+
+		return nextDisposal;
+	}
+
+	private trackQueryRunnerRelease(generation: number, queryRunner: QueryRunner): void {
+		const originalRelease: QueryRunner["release"] = queryRunner.release.bind(queryRunner);
+		let isTrackedReleaseHandled: boolean = false;
+
+		queryRunner.release = async (): Promise<void> => {
+			let shouldHandleTrackedRelease: boolean = false;
+
+			try {
+				await originalRelease();
+			} finally {
+				shouldHandleTrackedRelease = !isTrackedReleaseHandled;
+				isTrackedReleaseHandled = true;
+			}
+
+			if (!shouldHandleTrackedRelease) {
+				return;
+			}
+
+			this.decrementActiveQueryRunnerCount(generation);
+			await this.scheduleRetiredDriverDisposal(false);
+		};
+	}
+
 	private async validateConnectionHealth(dataSource: DataSource): Promise<void> {
 		if (!dataSource.isInitialized) {
 			this.LOGGER.warn("Current data source is not initialized, no health check needed");
@@ -185,8 +323,13 @@ export class RotatorService implements OnModuleInit {
 		try {
 			// Test the current connection with a simple query
 			const queryRunner: QueryRunner = dataSource.createQueryRunner();
-			await queryRunner.query("SELECT 1");
-			await queryRunner.release();
+
+			try {
+				await queryRunner.query("SELECT 1");
+			} finally {
+				await queryRunner.release();
+			}
+
 			this.LOGGER.debug("Current connection is healthy");
 		} catch (error) {
 			this.LOGGER.warn(`Current connection health check failed: ${error instanceof Error ? error.message : String(error)}`);
@@ -194,11 +337,24 @@ export class RotatorService implements OnModuleInit {
 		}
 	}
 
+	private validateRotationDataSourceOptions(options: DataSourceOptions): void {
+		if (options.type === "mysql" || options.type === "postgres") {
+			return;
+		}
+
+		throw new Error(`Database rotation is supported only for "mysql" and "postgres" data sources. Received: "${options.type}".`);
+	}
+
 	private async verifyNewConnection(dataSource: DataSource): Promise<void> {
 		try {
 			const queryRunner: QueryRunner = dataSource.createQueryRunner();
-			await queryRunner.query("SELECT 1");
-			await queryRunner.release();
+
+			try {
+				await queryRunner.query("SELECT 1");
+			} finally {
+				await queryRunner.release();
+			}
+
 			this.LOGGER.debug("New connection verified successfully");
 		} catch (error) {
 			this.LOGGER.error(`New connection verification failed: ${error instanceof Error ? error.message : String(error)}`);

--- a/test/typeorm-aws-connector/core-database-config.constant.mjs
+++ b/test/typeorm-aws-connector/core-database-config.constant.mjs
@@ -1,7 +1,7 @@
 import { EDatabaseType } from "@elsikora/nestjs-typeorm-aws-connector";
 
 const CORE_DATABASE_CONFIG = {
-	databaseName: "spinwin_core",
+	databaseName: "test_core",
 	entities: [],
 	host: "core-host",
 	password: "core-password",

--- a/test/typeorm-aws-connector/provider-database-config.constant.mjs
+++ b/test/typeorm-aws-connector/provider-database-config.constant.mjs
@@ -1,7 +1,7 @@
 import { EDatabaseType } from "@elsikora/nestjs-typeorm-aws-connector";
 
 const PROVIDER_DATABASE_CONFIG = {
-	databaseName: "spinwin_quickspin",
+	databaseName: "test_provider",
 	entities: [],
 	host: "provider-host",
 	password: "provider-password",

--- a/test/typeorm-aws-connector/typeorm-aws-connector.module.spec.mjs
+++ b/test/typeorm-aws-connector/typeorm-aws-connector.module.spec.mjs
@@ -15,6 +15,130 @@ import { PROVIDER_DATA_SOURCE } from "./provider-data-source.constant.mjs";
 import { ProviderConnectorProbeService } from "./provider-connector-probe.service.mjs";
 import { TestAppModule } from "./test-app.module.mjs";
 
+const DEFAULT_FAKE_OPTIONS = {
+	database: "app",
+	entities: [],
+	extra: {
+		max: 10,
+	},
+	host: "db-host",
+	logging: false,
+	password: "old-password",
+	port: 5432,
+	relationLoadStrategy: "query",
+	synchronize: false,
+	type: "postgres",
+	username: "old-user",
+};
+
+const cloneExtraOptions = (value) => {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		return {};
+	}
+
+	return {
+		...value,
+	};
+};
+
+const createFakeDriver = (label, dataSource) => {
+	const state = {
+		disconnectCalls: 0,
+		queryCalls: [],
+	};
+
+	const driver = {
+		connection: dataSource,
+		createQueryRunner: (mode = "master") => {
+			const queryRunner = {
+				connection: dataSource,
+				driver: undefined,
+				isReleased: false,
+				manager: undefined,
+				mode,
+				query: async (query) => {
+					state.queryCalls.push(query);
+
+					return [{ ok: 1 }];
+				},
+				release: async () => {
+					queryRunner.isReleased = true;
+				},
+			};
+
+			queryRunner.driver = driver;
+
+			return queryRunner;
+		},
+		disconnect: async () => {
+			state.disconnectCalls += 1;
+		},
+		label,
+		options: dataSource.options,
+		state,
+	};
+
+	return driver;
+};
+
+const createFakeDataSource = ({ label, options = {} }) => {
+	const dataSource = {
+		createQueryRunner(mode = "master") {
+			return dataSource.driver.createQueryRunner(mode);
+		},
+		destroyCalls: 0,
+		driver: undefined,
+		initialize: async () => {
+			dataSource.isInitialized = true;
+
+			return dataSource;
+		},
+		isInitialized: true,
+		options: {
+			...DEFAULT_FAKE_OPTIONS,
+			...options,
+			extra: {
+				...cloneExtraOptions(DEFAULT_FAKE_OPTIONS.extra),
+				...cloneExtraOptions(options.extra),
+			},
+		},
+		setOptions(nextOptions) {
+			dataSource.options = {
+				...dataSource.options,
+				...nextOptions,
+				extra: {
+					...cloneExtraOptions(dataSource.options.extra),
+					...cloneExtraOptions(nextOptions.extra),
+				},
+			};
+			dataSource.driver.options = dataSource.options;
+
+			return dataSource;
+		},
+		destroy: async () => {
+			dataSource.destroyCalls += 1;
+			dataSource.isInitialized = false;
+		},
+	};
+
+	const driver = createFakeDriver(label, dataSource);
+
+	dataSource.driver = driver;
+
+	return dataSource;
+};
+
+class TestRotatorService extends RotatorService {
+	constructor(dataSource, schedulerRegistry, connectorService, rotationIntervalName, replacementDataSource) {
+		super(dataSource, schedulerRegistry, connectorService, rotationIntervalName);
+		this.replacementDataSource = replacementDataSource;
+	}
+
+	createReplacementDataSource() {
+		return this.replacementDataSource;
+	}
+}
+
 describe("TypeOrmAwsConnectorModule", () => {
 	it("isolates multiple connector registrations in one Nest application", async () => {
 		const app = await NestFactory.createApplicationContext(TestAppModule, {
@@ -66,13 +190,20 @@ describe("TypeOrmAwsConnectorModule", () => {
 				isEnabled: true,
 			}),
 		};
-		const dataSource = {};
+
+		const firstDataSource = createFakeDataSource({
+			label: "first",
+		});
+
+		const secondDataSource = createFakeDataSource({
+			label: "second",
+		});
 
 		globalThis.setInterval = (callback, timeout) => ({ callback, timeout });
 
 		try {
-			const firstRotatorService = new RotatorService(dataSource, schedulerRegistry, connectorService, "db-rotation:1");
-			const secondRotatorService = new RotatorService(dataSource, schedulerRegistry, connectorService, "db-rotation:2");
+			const firstRotatorService = new RotatorService(firstDataSource, schedulerRegistry, connectorService, "db-rotation:1");
+			const secondRotatorService = new RotatorService(secondDataSource, schedulerRegistry, connectorService, "db-rotation:2");
 
 			firstRotatorService.onModuleInit();
 			secondRotatorService.onModuleInit();
@@ -95,6 +226,142 @@ describe("TypeOrmAwsConnectorModule", () => {
 			assert.ok(legacyProbe.rotatorService instanceof RotatorService);
 		} finally {
 			await app.close();
+		}
+	});
+
+	it("skips interval registration when rotation is disabled in config", () => {
+		let addIntervalCalls = 0;
+
+		const schedulerRegistry = {
+			addInterval: () => {
+				addIntervalCalls += 1;
+			},
+		};
+
+		const connectorService = {
+			getRotationConfig: () => ({
+				intervalMs: 1_000,
+				isEnabled: false,
+			}),
+		};
+		const rotatorService = new RotatorService(undefined, schedulerRegistry, connectorService, "db-rotation:disabled");
+
+		rotatorService.onModuleInit();
+
+		assert.equal(addIntervalCalls, 0);
+	});
+
+	it("resolves rotation config from SSM when raw overrides are not provided", () => {
+		const resolvedLookups = [];
+
+		const connectorService = new TypeOrmAwsConnectorService(
+			{
+				get: () => undefined,
+			},
+			{
+				get: (lookup) => {
+					resolvedLookups.push(lookup.path.join("/"));
+
+					if (lookup.path.join("/") === "typeorm/rotation/interval-ms") {
+						return "600000";
+					}
+
+					if (lookup.path.join("/") === "typeorm/rotation/enabled") {
+						return "true";
+					}
+
+					return null;
+				},
+			},
+			{
+				entities: [],
+			},
+		);
+
+		assert.deepEqual(connectorService.getRotationConfig(), {
+			intervalMs: 600_000,
+			isEnabled: true,
+		});
+		assert.deepEqual(resolvedLookups, ["typeorm/rotation/interval-ms", "typeorm/rotation/enabled"]);
+	});
+
+	it("promotes a verified replacement driver without destroying the live data source", async () => {
+		const originalSetInterval = globalThis.setInterval;
+
+		const liveDataSource = createFakeDataSource({
+			label: "live",
+			options: {
+				extra: {
+					applicationName: "rotation-test",
+					max: 10,
+				},
+			},
+		});
+		const originalDriver = liveDataSource.driver;
+
+		const replacementDataSource = createFakeDataSource({
+			label: "replacement",
+			options: {
+				extra: {
+					idleTimeoutMillis: 30_000,
+					max: 20,
+				},
+				host: "rotated-host",
+				password: "new-password",
+				username: "new-user",
+			},
+		});
+
+		const connectorService = {
+			getRotationConfig: () => ({
+				intervalMs: 1_000,
+				isEnabled: true,
+			}),
+			getTypeOrmOptions: async () => replacementDataSource.options,
+		};
+
+		const schedulerRegistry = {
+			addInterval: () => undefined,
+		};
+
+		globalThis.setInterval = () => ({
+			callback: undefined,
+			timeout: 1_000,
+		});
+
+		try {
+			const rotatorService = new TestRotatorService(liveDataSource, schedulerRegistry, connectorService, "db-rotation:test", replacementDataSource);
+
+			rotatorService.onModuleInit();
+
+			const inFlightQueryRunner = liveDataSource.createQueryRunner();
+
+			assert.equal(inFlightQueryRunner.driver.label, "live");
+
+			await rotatorService.rotateDatabaseConnection();
+
+			assert.equal(liveDataSource.destroyCalls, 0);
+			assert.equal(replacementDataSource.destroyCalls, 0);
+			assert.equal(liveDataSource.driver.label, "replacement");
+			assert.equal(liveDataSource.driver.connection, liveDataSource);
+			assert.equal(liveDataSource.options.host, "rotated-host");
+			assert.equal(liveDataSource.options.password, "new-password");
+			assert.equal(liveDataSource.options.username, "new-user");
+			assert.equal(liveDataSource.options.extra.applicationName, "rotation-test");
+			assert.equal(liveDataSource.options.extra.idleTimeoutMillis, 30_000);
+			assert.equal(liveDataSource.options.extra.max, 20);
+			assert.equal(originalDriver.state.disconnectCalls, 0);
+
+			const rotatedQueryRunner = liveDataSource.createQueryRunner();
+
+			assert.equal(rotatedQueryRunner.driver.label, "replacement");
+
+			await rotatedQueryRunner.release();
+			await inFlightQueryRunner.release();
+
+			assert.equal(originalDriver.state.disconnectCalls, 1);
+		} finally {
+			globalThis.setInterval = originalSetInterval;
 		}
 	});
 });


### PR DESCRIPTION
Promote a verified replacement driver before retiring the previous pool so in-flight work is not left with a disconnected driver. Add regression coverage and docs for disabled rotation intervals and staged pool drainage.