### PR TITLE
fix: publish portable Connector declarations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,12 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Build
-        run: npm run build
+      - name: Verify package
+        run: |
+          npm run format
+          npm run lint:all
+          npm test
+          npm pack --dry-run
 
       - name: Release
         env:

--- a/package.json
+++ b/package.json
@@ -16,18 +16,26 @@
 	"type": "module",
 	"exports": {
 		".": {
-			"require": "./dist/cjs/index.js",
-			"import": "./dist/esm/index.js"
+			"import": {
+				"types": "./dist/esm/index.d.ts",
+				"default": "./dist/esm/index.js"
+			},
+			"require": {
+				"types": "./dist/cjs/index.d.ts",
+				"default": "./dist/cjs/index.js"
+			}
 		}
 	},
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
+	"types": "dist/cjs/index.d.ts",
 	"files": [
 		"dist"
 	],
 	"scripts": {
 		"prebuild": "rimraf dist",
 		"build": "npm run prebuild && rollup -c",
+		"postbuild": "node scripts/normalize-declaration-imports.mjs",
 		"commit": "cz",
 		"format": "prettier --check .",
 		"format:fix": "prettier --write .",
@@ -41,7 +49,8 @@
 		"lint:watch": "npx eslint-watch ./",
 		"prepare": "husky",
 		"release": "semantic-release",
-		"test": "npm run build && node --test test/typeorm-aws-connector/rotator.service.spec.mjs test/typeorm-aws-connector/typeorm-aws-connector.module.spec.mjs"
+		"test": "npm run build && npm run test:consumer && node --test test/typeorm-aws-connector/rotator.service.spec.mjs test/typeorm-aws-connector/typeorm-aws-connector.module.spec.mjs",
+		"test:consumer": "tsc --project test/consumer/tsconfig.json && tsc --project test/consumer/tsconfig.bundler.json && node test/consumer/smoke.cjs"
 	},
 	"config": {
 		"commitizen": {

--- a/scripts/normalize-declaration-imports.mjs
+++ b/scripts/normalize-declaration-imports.mjs
@@ -1,0 +1,67 @@
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+async function main() {
+	const esmDeclarationRoot = path.resolve("dist/esm");
+	const declarationRoots = [esmDeclarationRoot, path.resolve("dist/cjs")];
+	const relativeSpecifierPattern = /((?:\bfrom\s+|\bimport\s*\(\s*|\brequire\s*\(\s*)["'])(\.\.?\/[^"'()]+)(["'])/gu;
+	const runtimeExtensionPattern = /\.(?:cjs|js|json|mjs|node)$/u;
+
+	const collectDeclarationPaths = async (directoryPath) => {
+		const declarationPaths = [];
+
+		for (const entry of await readdir(directoryPath, { withFileTypes: true })) {
+			const entryPath = path.join(directoryPath, entry.name);
+
+			if (entry.isDirectory()) {
+				declarationPaths.push(...(await collectDeclarationPaths(entryPath)));
+			} else if (entry.name.endsWith(".d.ts")) {
+				declarationPaths.push(entryPath);
+			}
+		}
+
+		return declarationPaths;
+	};
+
+	let normalizedSpecifierCount = 0;
+
+	for (const declarationPath of await collectDeclarationPaths(esmDeclarationRoot)) {
+		const contents = await readFile(declarationPath, "utf8");
+
+		const normalizedContents = contents.replace(relativeSpecifierPattern, (match, prefix, specifier, suffix) => {
+			if (runtimeExtensionPattern.test(specifier)) {
+				return match;
+			}
+
+			normalizedSpecifierCount += 1;
+
+			return `${prefix}${specifier}.js${suffix}`;
+		});
+
+		if (normalizedContents !== contents) {
+			await writeFile(declarationPath, normalizedContents);
+		}
+	}
+
+	for (const declarationRoot of declarationRoots) {
+		for (const declarationPath of await collectDeclarationPaths(declarationRoot)) {
+			const contents = await readFile(declarationPath, "utf8");
+
+			if (contents.includes("node_modules/")) {
+				throw new Error(`Generated declaration contains a repository-local dependency path: ${path.relative(process.cwd(), declarationPath)}`);
+			}
+
+			if (declarationRoot === esmDeclarationRoot) {
+				for (const match of contents.matchAll(relativeSpecifierPattern)) {
+					if (!runtimeExtensionPattern.test(match[2])) {
+						throw new Error(`Generated ESM declaration contains an extensionless relative specifier: ${path.relative(process.cwd(), declarationPath)} -> ${match[2]}`);
+					}
+				}
+			}
+		}
+	}
+
+	process.stdout.write(`Normalized ${String(normalizedSpecifierCount)} ESM declaration specifiers.\n`);
+}
+
+await main();

--- a/src/modules/typeorm-aws-connector/typeorm-aws-connector.service.ts
+++ b/src/modules/typeorm-aws-connector/typeorm-aws-connector.service.ts
@@ -1,5 +1,5 @@
 import type { IAwsDatabaseCredentialsSecret } from "@shared/interface/aws";
-import type { IStructuredLookup, ITypeOrmAwsConnectorConfig } from "@shared/interface/typeorm-aws-connector";
+import type { IStructuredLookup, ITypeOrmAwsConnectorConfig, ITypeOrmAwsConnectorParameterStoreConfigReader } from "@shared/interface/typeorm-aws-connector";
 import type { TTypeOrmAwsConnectorResolvedRotationConfig } from "@shared/type/typeorm-aws-connector";
 import type { DataSourceOptions } from "typeorm";
 
@@ -16,7 +16,8 @@ export class TypeOrmAwsConnectorService {
 
 	constructor(
 		private readonly configService: ConfigService,
-		private readonly parameterStoreConfigService: ParameterStoreConfigService,
+		@Inject(ParameterStoreConfigService)
+		private readonly parameterStoreConfigService: ITypeOrmAwsConnectorParameterStoreConfigReader,
 		@Inject(DATABASE_CONFIG_PROVIDER)
 		private readonly databaseConfig: ITypeOrmAwsConnectorConfig,
 	) {}

--- a/src/shared/interface/typeorm-aws-connector/index.ts
+++ b/src/shared/interface/typeorm-aws-connector/index.ts
@@ -1,5 +1,6 @@
 export { type ITypeOrmAwsConnectorConfig } from "./config.interface";
 export { type ITypeOrmAwsConnectorModuleAsyncOptions } from "./module-async-options.interface";
+export { type ITypeOrmAwsConnectorParameterStoreConfigReader } from "./parameter-store-config-reader.interface";
 export type * from "./rotation";
 export { type ITypeOrmAwsConnectorSsmLookupDefaults } from "./ssm-lookup-defaults.interface";
 export { type ITypeOrmAwsConnectorSsmLookups } from "./ssm-lookups.interface";

--- a/src/shared/interface/typeorm-aws-connector/module-async-options.interface.ts
+++ b/src/shared/interface/typeorm-aws-connector/module-async-options.interface.ts
@@ -1,4 +1,4 @@
-import type { InjectionToken, ModuleMetadata, OptionalFactoryDependency } from "@nestjs/common/interfaces";
+import type { InjectionToken, ModuleMetadata, OptionalFactoryDependency } from "@nestjs/common";
 
 import type { ITypeOrmAwsConnectorConfig } from "./config.interface";
 

--- a/src/shared/interface/typeorm-aws-connector/parameter-store-config-reader.interface.ts
+++ b/src/shared/interface/typeorm-aws-connector/parameter-store-config-reader.interface.ts
@@ -1,0 +1,5 @@
+import type { IStructuredLookup } from "./structured-lookup.interface";
+
+export interface ITypeOrmAwsConnectorParameterStoreConfigReader {
+	get(properties: IStructuredLookup): null | string;
+}

--- a/src/shared/interface/typeorm-aws-connector/structured-lookup.interface.ts
+++ b/src/shared/interface/typeorm-aws-connector/structured-lookup.interface.ts
@@ -1,3 +1,7 @@
-import type { IConfigGetProperties } from "@elsikora/nestjs-aws-parameter-store-config";
-
-export type IStructuredLookup = IConfigGetProperties;
+export interface IStructuredLookup {
+	application?: string;
+	environment?: string;
+	instanceName?: string;
+	namespace?: string;
+	path: Array<string>;
+}

--- a/src/shared/type/typeorm-aws-connector/module-options.type.ts
+++ b/src/shared/type/typeorm-aws-connector/module-options.type.ts
@@ -1,4 +1,4 @@
-import type { InjectionToken } from "@nestjs/common/interfaces";
+import type { InjectionToken } from "@nestjs/common";
 import type { ITypeOrmAwsConnectorConfig } from "@shared/interface/typeorm-aws-connector/config.interface";
 
 export type TTypeOrmAwsConnectorModuleOptions = {

--- a/test/consumer/no-default.mts
+++ b/test/consumer/no-default.mts
@@ -1,0 +1,4 @@
+// @ts-expect-error -- The ESM runtime has named exports and no default export.
+import connector from "@elsikora/nestjs-typeorm-aws-connector";
+
+void connector;

--- a/test/consumer/smoke.cjs
+++ b/test/consumer/smoke.cjs
@@ -1,0 +1,7 @@
+"use strict";
+
+const { ETypeOrmAwsConnectorRotationEvent, TypeOrmAwsConnectorModule } = require("@elsikora/nestjs-typeorm-aws-connector");
+
+if (typeof TypeOrmAwsConnectorModule.register !== "function" || ETypeOrmAwsConnectorRotationEvent.GENERATION_RETIRED !== "GENERATION_RETIRED") {
+	throw new Error("Connector CommonJS exports are invalid.");
+}

--- a/test/consumer/smoke.cts
+++ b/test/consumer/smoke.cts
@@ -1,0 +1,14 @@
+import { ETypeOrmAwsConnectorRotationEvent, TypeOrmAwsConnectorModule, type TDatabaseConfigRotation } from "@elsikora/nestjs-typeorm-aws-connector";
+
+const rotation: TDatabaseConfigRotation = {
+	isEnabled: false,
+};
+
+const dynamicModule = TypeOrmAwsConnectorModule.register({
+	entities: [],
+	rotation,
+});
+
+if (dynamicModule.module !== TypeOrmAwsConnectorModule || ETypeOrmAwsConnectorRotationEvent.DRAIN_TIMEOUT !== "DRAIN_TIMEOUT") {
+	throw new Error("Unexpected Connector CommonJS declaration contract.");
+}

--- a/test/consumer/smoke.mts
+++ b/test/consumer/smoke.mts
@@ -1,0 +1,22 @@
+import { ETypeOrmAwsConnectorRotationDeferredReason, ETypeOrmAwsConnectorRotationEvent, TypeOrmAwsConnectorModule, type TDatabaseConfigRotation, type TTypeOrmAwsConnectorRotationEvent } from "@elsikora/nestjs-typeorm-aws-connector";
+
+const onEvent = (event: TTypeOrmAwsConnectorRotationEvent): void => {
+	if (event.type === ETypeOrmAwsConnectorRotationEvent.ROTATION_DEFERRED && event.reason === ETypeOrmAwsConnectorRotationDeferredReason.RETIRING_GENERATION_ACTIVE) {
+		void event.retiringGeneration;
+	}
+};
+
+const rotation: TDatabaseConfigRotation = {
+	isEnabled: true,
+	onEvent,
+	shutdownDrainTimeoutMs: 15_000,
+};
+
+const dynamicModule = TypeOrmAwsConnectorModule.register({
+	entities: [],
+	rotation,
+});
+
+if (dynamicModule.module !== TypeOrmAwsConnectorModule) {
+	throw new Error("Unexpected Connector dynamic module export.");
+}

--- a/test/consumer/tsconfig.bundler.json
+++ b/test/consumer/tsconfig.bundler.json
@@ -1,0 +1,8 @@
+{
+	"compilerOptions": {
+		"module": "ESNext",
+		"moduleResolution": "Bundler"
+	},
+	"extends": "./tsconfig.json",
+	"files": ["smoke.mts"]
+}

--- a/test/consumer/tsconfig.json
+++ b/test/consumer/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"compilerOptions": {
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"noEmit": true,
+		"skipLibCheck": false,
+		"strict": true,
+		"target": "ES2022",
+		"types": ["node"]
+	},
+	"files": ["no-default.mts", "smoke.cts", "smoke.mts"]
+}


### PR DESCRIPTION
## Summary
- publish condition-specific ESM and CommonJS declarations and normalize ESM relative specifiers
- remove declaration coupling to broken dependency subpaths through Connector-owned structural contracts
- enforce strict NodeNext, Bundler, CJS runtime, and complete package gates before semantic-release

## Regression
The published `2.0.0-dev.1` beta fails strict NodeNext compilation because TypeScript selects ESM declarations with extensionless imports. This fix is intended to publish a verified `2.0.0-dev.2` replacement.

## Test plan
- [x] `npm run format`
- [x] `npm run lint:all`
- [x] `npm test` (strict consumer checks plus 22 package tests)
- [x] `npm pack --dry-run`
- [x] focused declaration-packaging review